### PR TITLE
🐛 Nginx 설정 오류 수정 및 배포 안정성 개선

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -115,6 +115,3 @@ jobs:
             fi
             
             echo "🎉 Dev 서버 배포 완료!"
-            echo "📌 접속 URL: http://${{ secrets.EC2_HOST }}"
-            echo "📌 SSL 설정이 필요한 경우 scripts/setup-ssl.sh 스크립트를 실행하세요"
-            

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -43,7 +43,7 @@ http {
     gzip on;
     gzip_vary on;
     gzip_min_length 10240;
-    gzip_proxied expired no-cache no-store private must-revalidate;
+    gzip_proxied expired no-cache no-store private auth;
     gzip_types
         text/plain
         text/css


### PR DESCRIPTION
## 🚨 **해결된 문제**

### **Nginx 컨테이너 시작 실패**
```bash
# 이전 에러
nginx: [emerg] invalid value "must-revalidate" in /etc/nginx/nginx.conf:46
```
→ nginx 컨테이너가 시작되지 않아 Mixed Content 해결 불가

## 🔧 **수정사항**

### **nginx.conf 문법 오류 수정**
```nginx
# AS-IS (에러 발생)
gzip_proxied expired no-cache no-store private must-revalidate;

# TO-BE (정상 동작)  
gzip_proxied expired no-cache no-store private auth;
```