### PR TITLE
✨ 폴더 생성, 조회 및 리뷰 저장 API 구현

### DIFF
--- a/src/main/java/com/toktot/common/exception/ErrorCode.java
+++ b/src/main/java/com/toktot/common/exception/ErrorCode.java
@@ -83,7 +83,15 @@ public enum ErrorCode {
     DATABASE_ERROR("데이터베이스 오류가 발생했습니다."),
     NETWORK_ERROR("네트워크 오류가 발생했습니다."),
     TIMEOUT_ERROR("요청 시간이 초과되었습니다."),
-    UNKNOWN_ERROR("알 수 없는 오류가 발생했습니다.");
+    UNKNOWN_ERROR("알 수 없는 오류가 발생했습니다."),
+
+    // 리뷰 조회 에러 (REVIEW)
+    REVIEW_NOT_FOUND("존재하지 않는 리뷰 입니다."),
+
+    // 폴더 에러 (FOLDER)
+    FOLDER_NOT_FOUND("존재하지 않는 폴더 입니다.");
+
+    ;
 
     private final String message;
 

--- a/src/main/java/com/toktot/config/security/SecurityConfig.java
+++ b/src/main/java/com/toktot/config/security/SecurityConfig.java
@@ -63,9 +63,6 @@ public class SecurityConfig {
             "/api/health",
             "/actuator/health",
             "/actuator/info",
-
-            // CORS 프리플라이트 요청 허용
-            "/v1/**"  // OPTIONS 요청을 위해 임시로 추가
     };
 
     public static boolean isPublicUrl(String path) {
@@ -76,8 +73,8 @@ public class SecurityConfig {
     static final String[] PROTECTED_URLS = {
             "/v1/users/**",
             "/v1/reviews/**",
-            "/v1/bookmarks/**",
-            "/v1/routes/**"
+            "/v1/folders/**",
+            "/v1/routes/**",
     };
 
     @Bean

--- a/src/main/java/com/toktot/domain/folder/Folder.java
+++ b/src/main/java/com/toktot/domain/folder/Folder.java
@@ -1,0 +1,56 @@
+package com.toktot.domain.folder;
+
+import com.toktot.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "folders")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Folder {
+
+    private static final String DEFAULT_FOLDER_NAME = "이름이 없는 폴더";
+    private static final int MAX_FOLDER_NAME_LENGTH = 50;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "folder_name", nullable = false, length = MAX_FOLDER_NAME_LENGTH)
+    private String folderName;
+
+    @OneToMany(mappedBy = "folder", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<FolderReview> folderReviews = new ArrayList<>();
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static Folder create(User user, String folderName) {
+        return Folder.builder()
+                .user(user)
+                .folderName(folderName)
+                .build();
+    }
+
+}

--- a/src/main/java/com/toktot/domain/folder/FolderReview.java
+++ b/src/main/java/com/toktot/domain/folder/FolderReview.java
@@ -1,0 +1,35 @@
+package com.toktot.domain.folder;
+
+import com.toktot.domain.review.Review;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "folder_reviews")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class FolderReview {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "folder_id", nullable = false)
+    private Folder folder;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/toktot/domain/folder/FolderReview.java
+++ b/src/main/java/com/toktot/domain/folder/FolderReview.java
@@ -32,4 +32,11 @@ public class FolderReview {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    public static FolderReview create(Folder folder, Review review) {
+        return FolderReview.builder()
+                .folder(folder)
+                .review(review)
+                .build();
+    }
 }

--- a/src/main/java/com/toktot/domain/folder/repository/FolderRepository.java
+++ b/src/main/java/com/toktot/domain/folder/repository/FolderRepository.java
@@ -1,0 +1,7 @@
+package com.toktot.domain.folder.repository;
+
+import com.toktot.domain.folder.Folder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FolderRepository extends JpaRepository<Folder, Long> {
+}

--- a/src/main/java/com/toktot/domain/folder/repository/FolderRepository.java
+++ b/src/main/java/com/toktot/domain/folder/repository/FolderRepository.java
@@ -1,7 +1,21 @@
 package com.toktot.domain.folder.repository;
 
 import com.toktot.domain.folder.Folder;
+import com.toktot.web.dto.folder.response.FolderResponse;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
+
+    @Query("SELECT new com.toktot.web.dto.folder.response.FolderResponse(" +
+            "f.id, f.folderName, COUNT(fr.review.id), f.createdAt) " +
+            "FROM Folder f " +
+            "LEFT JOIN f.folderReviews fr " +
+            "WHERE f.user.id = :userId " +
+            "GROUP BY f.id " +
+            "ORDER BY f.createdAt DESC")
+    List<FolderResponse> findFoldersWithReviewCountByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/toktot/domain/folder/repository/FolderReviewRepository.java
+++ b/src/main/java/com/toktot/domain/folder/repository/FolderReviewRepository.java
@@ -1,0 +1,7 @@
+package com.toktot.domain.folder.repository;
+
+import com.toktot.domain.folder.FolderReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FolderReviewRepository extends JpaRepository<FolderReview, Long> {
+}

--- a/src/main/java/com/toktot/domain/folder/service/FolderService.java
+++ b/src/main/java/com/toktot/domain/folder/service/FolderService.java
@@ -1,0 +1,30 @@
+package com.toktot.domain.folder.service;
+
+import com.toktot.domain.folder.Folder;
+import com.toktot.domain.folder.repository.FolderRepository;
+import com.toktot.domain.folder.repository.FolderReviewRepository;
+import com.toktot.domain.user.User;
+import com.toktot.web.dto.folder.response.FolderResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FolderService {
+
+    private final FolderRepository folderRepository;
+    private final FolderReviewRepository folderReviewRepository;
+
+    @Transactional
+    public FolderResponse createFolder(User user, String folderName) {
+
+        Folder folder = Folder.create(user, folderName);
+        folderRepository.save(folder);
+
+        return FolderResponse.from(folder);
+    }
+}

--- a/src/main/java/com/toktot/domain/folder/service/FolderService.java
+++ b/src/main/java/com/toktot/domain/folder/service/FolderService.java
@@ -10,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @Transactional(readOnly = true)
@@ -21,10 +23,13 @@ public class FolderService {
 
     @Transactional
     public FolderResponse createFolder(User user, String folderName) {
-
         Folder folder = Folder.create(user, folderName);
         folderRepository.save(folder);
 
         return FolderResponse.from(folder);
+    }
+
+    public List<FolderResponse> ReadFolders(User user) {
+        return folderRepository.findFoldersWithReviewCountByUserId(user.getId());
     }
 }

--- a/src/main/java/com/toktot/web/controller/folder/FolderController.java
+++ b/src/main/java/com/toktot/web/controller/folder/FolderController.java
@@ -4,6 +4,7 @@ import com.toktot.domain.folder.service.FolderService;
 import com.toktot.domain.user.User;
 import com.toktot.web.dto.ApiResponse;
 import com.toktot.web.dto.folder.request.FolderCreateRequest;
+import com.toktot.web.dto.folder.request.FolderReviewCreateRequest;
 import com.toktot.web.dto.folder.response.FolderResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -43,11 +44,30 @@ public class FolderController {
             @AuthenticationPrincipal User user) {
 
         log.atInfo()
-                .setMessage("Review foloder read request received")
+                .setMessage("Review folder read request received")
                 .addKeyValue("userId", user.getId())
                 .log();
 
-        List<FolderResponse> response = folderService.ReadFolders(user);
+        List<FolderResponse> response = folderService.readFolders(user);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/review-save")
+    public ResponseEntity<ApiResponse<List<FolderResponse>>> createReviewToFolders(
+            @AuthenticationPrincipal User user,
+            @RequestBody FolderReviewCreateRequest request,
+            @RequestBody Long reviewId) {
+
+        log.atInfo()
+                .setMessage("Save review in folder creation request received")
+                .addKeyValue("userId", user.getId())
+                .addKeyValue("reviewId", reviewId)
+                .addKeyValue("folders", request.folderIds())
+                .log();
+
+        folderService.createFolderReviews(user, request.folderIds(), reviewId);
+        List<FolderResponse> response = folderService.readFolders(user);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/toktot/web/controller/folder/FolderController.java
+++ b/src/main/java/com/toktot/web/controller/folder/FolderController.java
@@ -56,17 +56,16 @@ public class FolderController {
     @PostMapping("/review-save")
     public ResponseEntity<ApiResponse<List<FolderResponse>>> createReviewToFolders(
             @AuthenticationPrincipal User user,
-            @RequestBody FolderReviewCreateRequest request,
-            @RequestBody Long reviewId) {
+            @RequestBody FolderReviewCreateRequest request) {
 
         log.atInfo()
                 .setMessage("Save review in folder creation request received")
                 .addKeyValue("userId", user.getId())
-                .addKeyValue("reviewId", reviewId)
+                .addKeyValue("reviewId", request.reviewId())
                 .addKeyValue("folders", request.folderIds())
                 .log();
 
-        folderService.createFolderReviews(user, request.folderIds(), reviewId);
+        folderService.createFolderReviews(user, request.folderIds(), request.reviewId());
         List<FolderResponse> response = folderService.readFolders(user);
 
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/toktot/web/controller/folder/FolderController.java
+++ b/src/main/java/com/toktot/web/controller/folder/FolderController.java
@@ -10,10 +10,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -35,6 +34,20 @@ public class FolderController {
                 .log();
 
         FolderResponse response = folderService.createFolder(user, request.folderName());
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<FolderResponse>>> readFolders(
+            @AuthenticationPrincipal User user) {
+
+        log.atInfo()
+                .setMessage("Review foloder read request received")
+                .addKeyValue("userId", user.getId())
+                .log();
+
+        List<FolderResponse> response = folderService.ReadFolders(user);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/toktot/web/controller/folder/FolderController.java
+++ b/src/main/java/com/toktot/web/controller/folder/FolderController.java
@@ -1,0 +1,41 @@
+package com.toktot.web.controller.folder;
+
+import com.toktot.domain.folder.service.FolderService;
+import com.toktot.domain.user.User;
+import com.toktot.web.dto.ApiResponse;
+import com.toktot.web.dto.folder.request.FolderCreateRequest;
+import com.toktot.web.dto.folder.response.FolderResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/folders")
+@RequiredArgsConstructor
+public class FolderController {
+
+    private final FolderService folderService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<FolderResponse>> createFolder(
+            @Valid @RequestBody FolderCreateRequest request,
+            @AuthenticationPrincipal User user) {
+
+        log.atInfo()
+                .setMessage("Review folder creation request received")
+                .addKeyValue("userId", user.getId())
+                .addKeyValue("folderName", request.folderName())
+                .log();
+
+        FolderResponse response = folderService.createFolder(user, request.folderName());
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/toktot/web/dto/folder/request/FolderCreateRequest.java
+++ b/src/main/java/com/toktot/web/dto/folder/request/FolderCreateRequest.java
@@ -1,0 +1,11 @@
+package com.toktot.web.dto.folder.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
+
+public record FolderCreateRequest(
+        @JsonProperty(value = "folder_name")
+        @Size(max = 50, message = "폴더명은 최대 50자까지 입력 가능합니다.")
+        String folderName
+) {
+}

--- a/src/main/java/com/toktot/web/dto/folder/request/FolderReviewCreateRequest.java
+++ b/src/main/java/com/toktot/web/dto/folder/request/FolderReviewCreateRequest.java
@@ -1,0 +1,13 @@
+package com.toktot.web.dto.folder.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record FolderReviewCreateRequest(
+        @JsonProperty(value = "folder_ids")
+        @NotEmpty(message = "저장할 폴더를 최소 1개 이상 선택해주세요.")
+        List<Long> folderIds
+) {
+}

--- a/src/main/java/com/toktot/web/dto/folder/request/FolderReviewCreateRequest.java
+++ b/src/main/java/com/toktot/web/dto/folder/request/FolderReviewCreateRequest.java
@@ -8,6 +8,10 @@ import java.util.List;
 public record FolderReviewCreateRequest(
         @JsonProperty(value = "folder_ids")
         @NotEmpty(message = "저장할 폴더를 최소 1개 이상 선택해주세요.")
-        List<Long> folderIds
+        List<Long> folderIds,
+
+        @JsonProperty(value = "review_id")
+        @NotEmpty(message = "저장할 리뷰를 선택해주세요.")
+        Long reviewId
 ) {
 }

--- a/src/main/java/com/toktot/web/dto/folder/response/FolderResponse.java
+++ b/src/main/java/com/toktot/web/dto/folder/response/FolderResponse.java
@@ -1,6 +1,7 @@
 package com.toktot.web.dto.folder.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.toktot.domain.folder.Folder;
 import lombok.Builder;
 
@@ -9,9 +10,16 @@ import java.time.LocalDateTime;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record FolderResponse(
+        @JsonProperty(value = "folder_id")
         Long folderId,
+
+        @JsonProperty(value = "folder_name")
         String folderName,
+
+        @JsonProperty(value = "review_count")
         Long reviewCount,
+
+        @JsonProperty(value = "created_at")
         LocalDateTime createdAt
 ) {
 

--- a/src/main/java/com/toktot/web/dto/folder/response/FolderResponse.java
+++ b/src/main/java/com/toktot/web/dto/folder/response/FolderResponse.java
@@ -1,0 +1,33 @@
+package com.toktot.web.dto.folder.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.toktot.domain.folder.Folder;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record FolderResponse(
+        Long folderId,
+        String folderName,
+        Long reviewCount,
+        LocalDateTime createdAt
+) {
+
+    public static FolderResponse from(Folder folder) {
+        return FolderResponse.builder()
+                .folderId(folder.getId())
+                .folderName(folder.getFolderName())
+                .build();
+    }
+
+    public static FolderResponse from(Folder folder, Long reviewCount) {
+        return FolderResponse.builder()
+                .folderId(folder.getId())
+                .folderName(folder.getFolderName())
+                .reviewCount(reviewCount)
+                .build();
+    }
+
+}

--- a/src/main/java/com/toktot/web/dto/folder/response/FolderResponse.java
+++ b/src/main/java/com/toktot/web/dto/folder/response/FolderResponse.java
@@ -26,7 +26,7 @@ public record FolderResponse(
         return FolderResponse.builder()
                 .folderId(folder.getId())
                 .folderName(folder.getFolderName())
-                .reviewCount(reviewCount)
+                .reviewCount(reviewCount != null ? reviewCount : 0L)
                 .build();
     }
 


### PR DESCRIPTION
# ✨ 폴더 생성, 조회 및 리뷰 저장 기능 구현

## 작업 내용
- [x] 폴더 생성 API 구현
- [x] 폴더 목록 조회 API 구현 (리뷰 개수 포함)
- [x] 폴더에 리뷰 저장 API 구현
- [x] 폴더-리뷰 관계 엔티티 설계
- [x] 폴더 소유권 검증 로직 추가
- [x] API 응답 DTO 구조화

## 주요 변경사항

### 📋 리뷰 저장 기능
- 하나의 리뷰를 여러 폴더에 동시 저장 가능
- 존재하지 않는 폴더/리뷰에 대한 예외 처리

### 🔒 보안 및 검증
- 폴더 접근 권한 검증 (`ACCESS_DENIED` 예외)
- 리소스 존재 여부 확인 (`FOLDER_NOT_FOUND`, `REVIEW_NOT_FOUND`)

## API 엔드포인트
- `POST /v1/folders` - 폴더 생성
- `GET /v1/folders` - 폴더 목록 조회
- `POST /v1/folders/review-save` - 폴더에 리뷰 저장