### PR TITLE
✨ 사용자 차단 기능 구현

### DIFF
--- a/src/main/java/com/toktot/common/exception/ErrorCode.java
+++ b/src/main/java/com/toktot/common/exception/ErrorCode.java
@@ -51,6 +51,8 @@ public enum ErrorCode {
     DUPLICATE_REVIEW_REPORT("이미 신고한 리뷰입니다."),
     CANNOT_REPORT_OWN_USER("본인을 신고할 수 없습니다."),
     DUPLICATE_USER_REPORT("이미 신고한 사용자입니다."),
+    CANNOT_BLOCK_OWN_USER("본인을 차단할 수 없습니다."),
+    DUPLICATE_USER_BLOCK("이미 차단한 사용자입니다."),
 
     // 폴더 관련 에러 (FOLDER) - 기본 폴더 생성 실패 에러만 추가
     DEFAULT_FOLDER_CREATION_FAILED("기본 폴더 생성에 실패했습니다."),

--- a/src/main/java/com/toktot/domain/block/UserBlock.java
+++ b/src/main/java/com/toktot/domain/block/UserBlock.java
@@ -1,0 +1,42 @@
+package com.toktot.domain.block;
+
+import com.toktot.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Entity
+@Table(name = "user_blocks")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserBlock {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocker_user_id", nullable = false)
+    private User blockerUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocked_user_id", nullable = false)
+    private User blockedUser;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static UserBlock create(User blockerUser, User blockedUser) {
+        return UserBlock.builder()
+                .blockerUser(blockerUser)
+                .blockedUser(blockedUser)
+                .build();
+    }
+}

--- a/src/main/java/com/toktot/domain/block/UserBlockRepository.java
+++ b/src/main/java/com/toktot/domain/block/UserBlockRepository.java
@@ -1,0 +1,8 @@
+package com.toktot.domain.block;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
+
+    boolean existsByBlockerUser_IdAndBlockedUser_Id(Long blockerUserId, Long blockedUserId);
+}

--- a/src/main/java/com/toktot/domain/block/UserBlockService.java
+++ b/src/main/java/com/toktot/domain/block/UserBlockService.java
@@ -1,0 +1,52 @@
+package com.toktot.domain.block;
+
+import com.toktot.common.exception.ErrorCode;
+import com.toktot.common.exception.ToktotException;
+import com.toktot.domain.user.User;
+import com.toktot.domain.user.repository.UserRepository;
+import com.toktot.web.dto.block.UserBlockRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserBlockService {
+
+    private final UserBlockRepository userBlockRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void blockUser(UserBlockRequest request, User blocker) {
+        User blockedUser = findBlockedUser(request.blockedUserId());
+
+        checkSelfBlock(blocker.getId(), blockedUser.getId());
+        checkDuplicateBlock(blocker.getId(), blockedUser.getId());
+
+        UserBlock userBlock = UserBlock.create(blocker, blockedUser);
+        userBlockRepository.save(userBlock);
+
+        log.info("사용자 차단 완료 - blocker: {}, blocked: {}",
+                blocker.getId(), blockedUser.getId());
+    }
+
+    private User findBlockedUser(Long blockedUserId) {
+        return userRepository.findById(blockedUserId)
+                .orElseThrow(() -> new ToktotException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private void checkSelfBlock(Long blockerUserId, Long blockedUserId) {
+        if (blockerUserId.equals(blockedUserId)) {
+            throw new ToktotException(ErrorCode.CANNOT_BLOCK_OWN_USER);
+        }
+    }
+
+    private void checkDuplicateBlock(Long blockerUserId, Long blockedUserId) {
+        if (userBlockRepository.existsByBlockerUser_IdAndBlockedUser_Id(blockerUserId, blockedUserId)) {
+            throw new ToktotException(ErrorCode.DUPLICATE_USER_BLOCK);
+        }
+    }
+}

--- a/src/main/java/com/toktot/web/controller/block/UserBlockController.java
+++ b/src/main/java/com/toktot/web/controller/block/UserBlockController.java
@@ -1,0 +1,36 @@
+package com.toktot.web.controller.block;
+
+import com.toktot.domain.block.UserBlockService;
+import com.toktot.domain.user.User;
+import com.toktot.web.dto.ApiResponse;
+import com.toktot.web.dto.block.UserBlockRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/blocks/users")
+@RequiredArgsConstructor
+public class UserBlockController {
+
+    private final UserBlockService userBlockService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> blockUser(
+            @Valid @RequestBody UserBlockRequest request,
+            @AuthenticationPrincipal User user) {
+
+        log.atInfo()
+                .setMessage("사용자 차단")
+                .addKeyValue("blockerUserId", user.getId())
+                .addKeyValue("blockedUserId", request.blockedUserId())
+                .log();
+
+        userBlockService.blockUser(request, user);
+        return ResponseEntity.ok(ApiResponse.success("사용자를 차단했습니다."));
+    }
+}

--- a/src/main/java/com/toktot/web/dto/block/UserBlockRequest.java
+++ b/src/main/java/com/toktot/web/dto/block/UserBlockRequest.java
@@ -1,0 +1,11 @@
+package com.toktot.web.dto.block;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+public record UserBlockRequest(
+        @JsonProperty("blocked_user_id")
+        @NotNull(message = "차단할 사용자가 선택되지 않았습니다.")
+        Long blockedUserId
+) {
+}


### PR DESCRIPTION
## 작업 내용
- [x] 사용자 차단 에러코드 추가 (ErrorCode)
- [x] UserBlock 엔티티 및 Repository 구현
- [x] UserBlockService 비즈니스 로직 구현
- [x] UserBlockRequest DTO 구현
- [x] UserBlockController API 엔드포인트 구현
- [x] 본인 차단 방지 검증 로직
- [x] 중복 차단 방지 검증 로직

## 주요 변경사항

### 🎯 API 엔드포인트
- **POST** `/v1/blocks/users` - 사용자 차단 API 구현
- Request Body: `{"blocked_user_id": Long}`
- Response: 성공/실패 메시지와 에러코드

### 🔒 검증 로직
- 본인 차단 방지 (`CANNOT_BLOCK_OWN_USER`)
- 중복 차단 방지 (`DUPLICATE_USER_BLOCK`)
- 존재하지 않는 사용자 차단 방지 (`USER_NOT_FOUND`)

## 향후 확장 계획
- 차단된 사용자의 리뷰 필터링 로직