### PR TITLE
✨ 가게 하이브리드 검색 (카카오맵 + TourAPI)

### DIFF
--- a/src/main/java/com/toktot/domain/restaurant/Restaurant.java
+++ b/src/main/java/com/toktot/domain/restaurant/Restaurant.java
@@ -124,4 +124,9 @@ public class Restaurant {
     public void updateSyncTime() {
         this.lastSyncedAt = LocalDateTime.now();
     }
+
+    public void updateKakaoId(String kakaoId) {
+        this.externalKakaoId = kakaoId;
+        this.lastSyncedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/toktot/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/com/toktot/domain/restaurant/repository/RestaurantRepository.java
@@ -4,6 +4,7 @@ import com.toktot.domain.restaurant.Restaurant;
 import com.toktot.domain.restaurant.type.DataSource;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,4 +20,8 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
     List<Restaurant> findAllByDataSourceAndIsActive(DataSource dataSource, Boolean isActive);
 
+    List<Restaurant> findByLatitudeBetweenAndLongitudeBetween(
+            BigDecimal minLat, BigDecimal maxLat,
+            BigDecimal minLon, BigDecimal maxLon
+    );
 }

--- a/src/main/java/com/toktot/domain/restaurant/service/RestaurantLocationMatcher.java
+++ b/src/main/java/com/toktot/domain/restaurant/service/RestaurantLocationMatcher.java
@@ -1,0 +1,118 @@
+package com.toktot.domain.restaurant.service;
+
+import com.toktot.domain.restaurant.Restaurant;
+import com.toktot.domain.restaurant.repository.RestaurantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RestaurantLocationMatcher {
+
+    private static final double DEFAULT_MATCH_RADIUS_METERS = 50.0;
+
+    private final RestaurantRepository restaurantRepository;
+
+    public Optional<Restaurant> findExistingRestaurant(String restaurantName, BigDecimal latitude, BigDecimal longitude) {
+        if (latitude == null || longitude == null) {
+            return Optional.empty();
+        }
+
+        List<Restaurant> nearbyRestaurants = findRestaurantsWithinRadius(latitude, longitude, DEFAULT_MATCH_RADIUS_METERS);
+
+        if (nearbyRestaurants.isEmpty()) {
+            return Optional.empty();
+        }
+
+        if (restaurantName != null && !restaurantName.trim().isEmpty()) {
+            Optional<Restaurant> nameMatch = nearbyRestaurants.stream()
+                    .filter(r -> isSimilarName(restaurantName, r.getName()))
+                    .min((r1, r2) -> compareDistance(latitude, longitude, r1, r2));
+
+            if (nameMatch.isPresent()) {
+                log.debug("매장명+좌표 매칭: {} ≈ {}", restaurantName, nameMatch.get().getName());
+                return nameMatch;
+            }
+        }
+
+        Restaurant closest = nearbyRestaurants.stream()
+                .min((r1, r2) -> compareDistance(latitude, longitude, r1, r2))
+                .get();
+
+        double distance = calculateDistance(latitude, longitude, closest.getLatitude(), closest.getLongitude());
+        log.debug("좌표 매칭: {} (거리: {}m)", closest.getName(), Math.round(distance));
+
+        return Optional.of(closest);
+    }
+
+    private List<Restaurant> findRestaurantsWithinRadius(BigDecimal latitude, BigDecimal longitude, double radiusMeters) {
+        double[] bounds = calculateBounds(latitude, longitude, radiusMeters);
+
+        List<Restaurant> candidates = restaurantRepository.findByLatitudeBetweenAndLongitudeBetween(
+                BigDecimal.valueOf(bounds[0]), BigDecimal.valueOf(bounds[1]),
+                BigDecimal.valueOf(bounds[2]), BigDecimal.valueOf(bounds[3])
+        );
+
+        return candidates.stream()
+                .filter(r -> calculateDistance(latitude, longitude, r.getLatitude(), r.getLongitude()) <= radiusMeters)
+                .toList();
+    }
+
+    private boolean isSimilarName(String name1, String name2) {
+        if (name1 == null || name2 == null) return false;
+
+        String clean1 = name1.replaceAll("\\s+", "").toLowerCase();
+        String clean2 = name2.replaceAll("\\s+", "").toLowerCase();
+
+        return clean1.equals(clean2) || clean1.contains(clean2) || clean2.contains(clean1);
+    }
+
+    private int compareDistance(BigDecimal lat, BigDecimal lon, Restaurant r1, Restaurant r2) {
+        double dist1 = calculateDistance(lat, lon, r1.getLatitude(), r1.getLongitude());
+        double dist2 = calculateDistance(lat, lon, r2.getLatitude(), r2.getLongitude());
+        return Double.compare(dist1, dist2);
+    }
+
+    private double calculateDistance(BigDecimal lat1, BigDecimal lon1, BigDecimal lat2, BigDecimal lon2) {
+        if (lat1 == null || lon1 == null || lat2 == null || lon2 == null) {
+            return Double.MAX_VALUE;
+        }
+
+        double lat1Rad = Math.toRadians(lat1.doubleValue());
+        double lon1Rad = Math.toRadians(lon1.doubleValue());
+        double lat2Rad = Math.toRadians(lat2.doubleValue());
+        double lon2Rad = Math.toRadians(lon2.doubleValue());
+
+        double deltaLat = lat2Rad - lat1Rad;
+        double deltaLon = lon2Rad - lon1Rad;
+
+        double a = Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +
+                Math.cos(lat1Rad) * Math.cos(lat2Rad) *
+                        Math.sin(deltaLon / 2) * Math.sin(deltaLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return 6371.0 * c * 1000;
+    }
+
+    private double[] calculateBounds(BigDecimal centerLat, BigDecimal centerLon, double radiusMeters) {
+        double lat = centerLat.doubleValue();
+        double lon = centerLon.doubleValue();
+
+        double latOffset = radiusMeters / 111320.0;
+        double lonOffset = radiusMeters / (Math.cos(Math.toRadians(lat)) * 111320.0);
+
+        return new double[] {
+                lat - latOffset,
+                lat + latOffset,
+                lon - lonOffset,
+                lon + lonOffset
+        };
+    }
+}

--- a/src/main/java/com/toktot/domain/restaurant/service/RestaurantSearchService.java
+++ b/src/main/java/com/toktot/domain/restaurant/service/RestaurantSearchService.java
@@ -2,15 +2,22 @@ package com.toktot.domain.restaurant.service;
 
 import com.toktot.common.exception.ErrorCode;
 import com.toktot.common.exception.ToktotException;
+import com.toktot.domain.restaurant.Restaurant;
+import com.toktot.domain.restaurant.repository.RestaurantRepository;
 import com.toktot.external.kakao.KakaoApiConstants;
 import com.toktot.external.kakao.dto.request.RestaurantSearchRequest;
 import com.toktot.external.kakao.dto.response.KakaoPlaceSearchResponse;
 import com.toktot.external.kakao.service.KakaoMapService;
+import com.toktot.web.dto.restaurant.response.RestaurantInfoResponse;
 import com.toktot.web.dto.restaurant.response.RestaurantSearchResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -18,26 +25,97 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class RestaurantSearchService {
 
+    private final RestaurantRepository restaurantRepository;
     private final KakaoMapService kakaoMapService;
+    private final RestaurantLocationMatcher locationMatcher;
 
     public RestaurantSearchResponse searchFromKakaoWithPagination(RestaurantSearchRequest request) {
         validateSearchRequest(request);
 
         try {
             RestaurantSearchRequest currentRequest = request;
-            KakaoPlaceSearchResponse finalResponse = kakaoMapService.searchJejuAllFoodAndCafePlace(currentRequest);
+            KakaoPlaceSearchResponse kakaoResponse = kakaoMapService.searchJejuAllFoodAndCafePlace(currentRequest);
 
-            while (finalResponse.getPlaceInfos().size() < KakaoApiConstants.DEFAULT_SIZE && finalResponse.hasMorePages()) {
+            while (kakaoResponse.getPlaceInfos().size() < KakaoApiConstants.DEFAULT_SIZE && kakaoResponse.hasMorePages()) {
                 currentRequest = currentRequest.nextPage();
                 KakaoPlaceSearchResponse currentPageResponse = kakaoMapService.searchJejuAllFoodAndCafePlace(currentRequest);
-                finalResponse = currentPageResponse.mergeWithPreviousResults(finalResponse);
+                kakaoResponse = currentPageResponse.mergeWithPreviousResults(kakaoResponse);
             }
 
-            return RestaurantSearchResponse.from(finalResponse, currentRequest.page());
+            RestaurantSearchResponse basicResponse = RestaurantSearchResponse.from(kakaoResponse, currentRequest.page());
+            return combineKakaoAndDbData(basicResponse);
+
         } catch (Exception e) {
             log.error("Kakao search failed for request: {}", request, e);
             throw new ToktotException(ErrorCode.KAKAO_LOCAL_SERVICE_ERROR, e.getMessage());
         }
+    }
+
+    private RestaurantSearchResponse combineKakaoAndDbData(RestaurantSearchResponse kakaoResponse) {
+        List<RestaurantInfoResponse> restaurants = kakaoResponse.places();
+        List<RestaurantInfoResponse> combinedRestaurants = new ArrayList<>();
+
+        for (RestaurantInfoResponse restaurant : restaurants) {
+            // 1. 카카오 ID로 정확 매칭 시도
+            Optional<Restaurant> exactMatch = restaurantRepository.findByExternalKakaoId(restaurant.externalKakaoId());
+
+            if (exactMatch.isPresent()) {
+                combinedRestaurants.add(buildEnhancedResponse(restaurant, exactMatch.get()));
+                log.debug("카카오 ID 매칭: {} (ID: {})", exactMatch.get().getName(), exactMatch.get().getId());
+                continue;
+            }
+
+            // 2. 위치+매장명 기반 매칭 시도
+            Optional<Restaurant> locationMatch = locationMatcher.findExistingRestaurant(
+                    restaurant.name(),
+                    restaurant.latitude(),
+                    restaurant.longitude()
+            );
+
+            if (locationMatch.isPresent()) {
+                Restaurant matched = locationMatch.get();
+                // 카카오 ID가 없으면 업데이트
+                if (matched.getExternalKakaoId() == null) {
+                    updateKakaoId(matched, restaurant.externalKakaoId());
+                }
+                combinedRestaurants.add(buildEnhancedResponse(restaurant, matched));
+                log.debug("위치 매칭: {} → {} (ID: {})", restaurant.name(), matched.getName(), matched.getId());
+                continue;
+            }
+
+            // 3. DB 매칭 실패 시 카카오 데이터만 사용
+            combinedRestaurants.add(restaurant);
+            log.debug("카카오 전용: {}", restaurant.name());
+        }
+
+        return new RestaurantSearchResponse(
+                combinedRestaurants,
+                kakaoResponse.currentPage(),
+                kakaoResponse.is_end()
+        );
+    }
+
+    private RestaurantInfoResponse buildEnhancedResponse(RestaurantInfoResponse kakaoData, Restaurant dbEntity) {
+        return RestaurantInfoResponse.builder()
+                .id(dbEntity.getId())
+                .externalKakaoId(kakaoData.externalKakaoId())
+                .name(dbEntity.getName())
+                .address(kakaoData.address()) // 카카오 주소 사용 (더 정확)
+                .distance(kakaoData.distance())
+                .mainMenus(dbEntity.getPopularMenus())
+                .longitude(kakaoData.longitude()) // 카카오 좌표 사용
+                .latitude(kakaoData.latitude())
+                .isGoodPriceStore(dbEntity.getIsGoodPriceStore())
+                .isLocalStore(dbEntity.getIsLocalStore())
+                .image(dbEntity.getImage())
+                .build();
+    }
+
+    @Transactional
+    public void updateKakaoId(Restaurant restaurant, String kakaoId) {
+        restaurant.updateKakaoId(kakaoId); // Restaurant 엔티티에 메서드 추가 필요
+        restaurantRepository.save(restaurant);
+        log.info("카카오 ID 업데이트: {} → {}", restaurant.getName(), kakaoId);
     }
 
     private void validateSearchRequest(RestaurantSearchRequest request) {
@@ -45,5 +123,4 @@ public class RestaurantSearchService {
             throw new ToktotException(ErrorCode.INVALID_INPUT, "검색어를 입력해주세요.");
         }
     }
-
 }


### PR DESCRIPTION
## 작업 내용
- [x] 좌표 + 매장명 기반 매장 매칭 서비스 구현
- [x] Restaurant 엔티티에 카카오 ID 업데이트 기능 추가
- [x] Repository 좌표 범위 조회 메서드 추가
- [x] 검색 서비스에 위치 매칭 로직 적용

## 주요 변경사항
### 🎯 RestaurantLocationMatcher 서비스 추가
- 50m 반경 내 기존 매장 찾기 (Haversine 공식 사용)
- 매장명 유사도 매칭으로 정확도 향상
- 사각형 범위 1차 필터링 → 정확한 거리 2차 필터링