### PR TITLE
⚡ 가게 리스트 조회 API 불필요한 필드 제거

### DIFF
--- a/src/main/java/com/toktot/web/dto/restaurant/response/RestaurantInfoResponse.java
+++ b/src/main/java/com/toktot/web/dto/restaurant/response/RestaurantInfoResponse.java
@@ -11,31 +11,14 @@ import java.math.BigDecimal;
 @Builder
 public record RestaurantInfoResponse(
         Long id,
-        @JsonProperty("external_kakao_id")
-        String externalKakaoId,
-
         String name,
         String address,
         String distance,
-
-        @JsonProperty("main_menus")
-        String mainMenus,
-
-        @JsonProperty("average_rating")
-        BigDecimal averageRating,
-
-        @JsonProperty("review_count")
-        Long reviewCount,
-
-        BigDecimal longitude,
-
-        BigDecimal latitude,
-
-        @JsonProperty("is_good_price_store")
-        Boolean isGoodPriceStore,
-
-        @JsonProperty("is_local_store")
-        Boolean isLocalStore,
+        @JsonProperty("main_menus") String mainMenus,
+        @JsonProperty("average_rating") BigDecimal averageRating,
+        @JsonProperty("review_count") Long reviewCount,
+        @JsonProperty("is_good_price_store") Boolean isGoodPriceStore,
+        @JsonProperty("is_local_store") Boolean isLocalStore,
         String image,
         Integer point,
         Integer percent
@@ -43,25 +26,19 @@ public record RestaurantInfoResponse(
     public static RestaurantInfoResponse from(Restaurant entity, KakaoPlaceInfo kakaoPlaceInfo) {
         return RestaurantInfoResponse.builder()
                 .id(entity.getId())
-                .externalKakaoId(entity.getExternalKakaoId())
                 .name(entity.getName())
                 .address(extractCityAndDistrict(kakaoPlaceInfo.getAddressName()))
                 .distance(getDistance(kakaoPlaceInfo.getDistance()))
                 .mainMenus(entity.getPopularMenus())
-                .longitude(entity.getLongitude())
-                .latitude(entity.getLatitude())
                 .image(entity.getImage())
                 .build();
     }
 
     public static RestaurantInfoResponse from(KakaoPlaceInfo kakaoPlaceInfo) {
         return RestaurantInfoResponse.builder()
-                .externalKakaoId(kakaoPlaceInfo.getId())
                 .name(kakaoPlaceInfo.getPlaceName())
                 .address(extractCityAndDistrict(kakaoPlaceInfo.getAddressName()))
                 .distance(getDistance(kakaoPlaceInfo.getDistance()))
-                .longitude(kakaoPlaceInfo.getLongitude())
-                .latitude(kakaoPlaceInfo.getLatitude())
                 .build();
     }
 


### PR DESCRIPTION
## 📋 작업 내용
가게 리스트 조회 API 응답 최적화 - 불필요 필드 제거

## 🎯 작업 배경
카카오 로컬 API 데이터를 DB에 저장하게 되면서 더 이상 필요하지 않은 필드들을 API 응답에서 제거하여 응답 성능을 최적화합니다.

## ✅ 변경 사항
### 제거된 필드
- `external_kakao_id` - DB에서 ID 관리로 불필요
- `longitude` - 클라이언트에서 사용하지 않음  
- `latitude` - 클라이언트에서 사용하지 않음